### PR TITLE
feat(zb-log-check): adds Makefile, Dockerfile, and k8s sample

### DIFF
--- a/zb-log-check/Dockerfile
+++ b/zb-log-check/Dockerfile
@@ -1,0 +1,24 @@
+FROM maven:3.6.0-jdk-11 as builder
+ARG VERSION=0.1.0-SNAPSHOT
+
+COPY ./src /usr/local/src/zb-log-check/src
+COPY ./pom.xml /usr/local/src/zb-log-check/pom.xml
+WORKDIR /usr/local/src/zb-log-check
+
+RUN mvn clean package -DskipTests
+
+# Final image will only contain the built JAR and the configuration file and some UNIX utilities
+FROM adoptopenjdk/openjdk11:jre-11.0.6_10-alpine as application
+ARG VERSION=0.1.0-SNAPSHOT
+ARG WORKDIR=/usr/local/zb-log-check
+ARG DATA_DIR=${WORKDIR}/zeebe
+
+COPY --from=builder /usr/local/src/zb-log-check/target/zb-log-check-${VERSION}-jar-with-dependencies.jar ${WORKDIR}/zb-log-check.jar
+
+ENV WORKDIR ${WORKDIR}
+ENV ZB_LOG_CHECK_DATA_DIR ${DATA_DIR}
+RUN mkdir -p "$WORKDIR"
+WORKDIR ${WORKDIR}
+
+VOLUME ${DATA_DIR}
+ENTRYPOINT java -jar zb-log-check.jar ${ZB_LOG_CHECK_DATA_DIR:-$(pwd)/zeebe}

--- a/zb-log-check/Makefile
+++ b/zb-log-check/Makefile
@@ -1,0 +1,18 @@
+.DEFAULT: docker
+
+GET_VERSION = $(shell mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn | grep -v "^\[")
+SET_VERSION = $(eval VERSION=$(GET_VERSION))
+
+# Eventually use the --squash flag when building (currently an experimental feature)
+.PHONY: docker-build
+docker-build:
+	$(SET_VERSION)
+	docker build -f Dockerfile --build-arg VERSION=$(VERSION) --target application -t gcr.io/zeebe-io/zb-log-check:$(VERSION) .
+
+.PHONY: docker-push
+docker-push:
+	$(SET_VERSION)
+	docker push gcr.io/zeebe-io/zb-log-check:$(VERSION)
+
+.PHONY: docker
+docker: docker-build docker-push

--- a/zb-log-check/README.md
+++ b/zb-log-check/README.md
@@ -1,0 +1,78 @@
+# Zeebe Log Check
+
+## Docker
+
+You can use the provided `Makefile` to build a small container which will run the application.
+
+To build and push at once, just run:
+
+```shell
+make docker
+```
+
+### Build
+
+The image is a multi-stage image, with two stages: `builder` and `application`.
+
+The builder is a simple maven based image which will create the application JAR, and the
+application is the actual container than can later be used.
+
+To build, run:
+
+```shell
+make docker-build 
+```
+
+### Push
+
+As the image is tagged for the Zeebe team repositories, it requires you to be have Docker configured to
+use Google Cloud authentication credentials.
+
+To push, simply run:
+
+```shell
+make docker-push
+```
+
+## Kubernetes
+
+One of the best use cases for this is to use it as an init container for a Zeebe broker. This allows us to run
+consistency checks before the broker starts on its own data, making our tests much more robust.
+
+Here is a sample configuration you could use to describe an init container for a Zeebe broker:
+
+```yaml
+initContainers:
+  - name: zb-log-check
+    image: gcr.io/zeebe-io/zb-log-check:0.1.0
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: data
+      mountPath: "/usr/local/zb-log-check/zeebe/data"
+```
+
+If you want to use a different mount path, you can specify it as the environment variable `ZB_LOG_CHECK_DATA_DIR`
+```yaml
+initContainers:
+  - name: zb-log-check
+    image: gcr.io/zeebe-io/zb-log-check:0.1.0
+    imagePullPolicy: Always
+    env:
+      - name: ZB_LOG_CHECK_DATA_DIR
+        value: "/my/custom/path"
+    volumeMounts:
+    - name: data
+      mountPath: "/my/custom/path"
+```
+
+To use it with the Zeebe Helm charts, you can specify it under the `extraInitContainers` value:
+
+```yaml
+extraInitContainers: |
+  - name: zb-log-check
+    image: gcr.io/zeebe-io/zb-log-check:0.1.0
+    imagePullPolicy: Always
+    volumeMounts:
+    - name: data
+      mountPath: "/usr/local/zb-log-check/zeebe/data"
+```


### PR DESCRIPTION
**Description**

This adds a multi-stage `Dockerfile` which will be a small `AdoptOpenJDK11` based image with `zb-log-check`, with some default entry point. By default, the fat JAR lives at `/usr/local/zb-log-check`, and it expects to read from `/usr/local/zb-log-check/zeebe`, which is listed as a volume and should be mounted at runtime. You can also override this using the `ZB_LOG_CHECK_DATA_DIR` environment variable.

There's a `Makefile` to easily build and push the image (to our `gcr.io/zeebe-io/zb-log-check` repository), and the `README.md` contains examples on how to use it as an `initContainer`, which will help us identify faster when we have inconsistencies in our benchmarks.

Thanks for doing this @Zelldon :muscle: 